### PR TITLE
Error handling fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2
+jobs:
+  build:
+    docker:
+       - image: circleci/ruby:2.3.7
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: run tests
+          command: rspec spec/
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Client Auth
 ----------------
 
+[![CircleCI](https://circleci.com/gh/himaxwell/client-auth.svg?style=svg)](https://circleci.com/gh/himaxwell/client-auth)
+
 Client Authentication gem for Matic clients.
 
 Releasing

--- a/client-auth.gemspec
+++ b/client-auth.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Authentication client'
   spec.description   = 'Authentication for matic clients'
-  spec.homepage      = 'https://github.com/matic-insurance/client-auth'
+  spec.homepage      = 'https://github.com/himaxwell/client-auth'
 
   spec.files = Dir['lib/**/*.rb']
   spec.files += Dir['README.markdown']

--- a/lib/client_auth/models/error_serializer.rb
+++ b/lib/client_auth/models/error_serializer.rb
@@ -10,6 +10,8 @@ module ClientAuth
       attrs = JSON.parse(data)['errors'].first
       klass = attrs['title'].constantize
       klass.new(attrs['status'], attrs['detail'])
+    rescue StandardError
+      ::ClientAuth::Errors::InternalServerError.new(data)
     end
   end
 end

--- a/spec/client_auth/authenticator_spec.rb
+++ b/spec/client_auth/authenticator_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe ClientAuth::Authenticator do
   subject { authenticate }
   let(:authenticate) { described_class.new(request, rsa_key).authenticate! }


### PR DESCRIPTION
We were receiving non-regular errors from Encompass, but this didn't know how to handle them. The result is we end up with useless errors because we lose the data that caused the error!

This PR makes the error handler pass up the data itself if it can't parse it.